### PR TITLE
Fix lookup for some words

### DIFF
--- a/leo
+++ b/leo
@@ -23,11 +23,13 @@ def translate(word, lang):
     )
 
     soup = BeautifulSoup(r.text, 'xml')
-    results = soup.find_all('entry')
-    if results:
-        results_translation = [res.find(hc=0).find('word').get_text() for res in results]
-        results_origin = [res.find(hc=1).find('word').get_text() for res in results]
-        return list(zip(results_origin, results_translation))
+
+    entries = soup.find_all('entry')
+    if entries:
+        return [tuple([side.find('word').get_text()
+                       for side in entry.find_all('side')])
+                for entry in entries]
+
 
 if sys.argv[1] in COUNTRY_CODES:
     lang = sys.argv[1] + 'de'


### PR DESCRIPTION
For some words, like 'nutritive', the lookup failed because there's no
&lt;side&gt; tag with hc=0 attribute in leo.org's XML output, but rather two
with both &lt;side&gt; tags having hc attributes set to 1.

Fix this by not looking at the "hc" attribute, but using the &lt;side&gt;
tags and the words in them directly.

```
$ ./leo nutritive
translating to: ende
nutritive   ernährend
nutritive   Ernährungs...
nutritive   Nähr...
[...]
```
