### PR TITLE
fix install dependencies

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,10 +11,6 @@ leo-cli is a command line tool which can be used to translate words or phrases f
 ===================
 This tool requires beatiful soup, the wonderful requests library and the tabulate library.
 
-###install dependencies
-
-pip install -r requirements.txt
-
 ###install leo-cli
 pip install leo-cli
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='leo-cli',
     license="MIT",
     url='https://github.com/JoiDegn/leo-cli',
     scripts=['leo'],
-    install_requires=['beautifulsoup4>=4.3.0', 'requests>=1.2.3', 'tabulate'],
+    install_requires=['beautifulsoup4>=4.3.0', 'lxml>=3.0', 'requests>=1.2.3', 'tabulate'],
     classifiers = [
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
better fix for issue #9.
users installing via pip and pypi don't checkout the git repo and don't know where to find `reuirements.txt`. instead dependencies should be included in `setup.py`, which is evaluated by pip.