### PR TITLE
Remove entry point "main"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,3 @@ packages = find:
 python_requires = >=3.6
 scripts = leo
 install_requires = file: requirements.txt
-
-[options.entry_points]
-console_scripts =
-    main = leo:main


### PR DESCRIPTION
I just noticed that when installing leo-cli with `pip` or `pipx`, a script called `main` is created in `.local/bin`.  It's superfluous because `leo` is created as well just as expected.

This commit removes the section that is responsible for this from `pyproject.toml`. Packaging for Python is a complete mess, so I can sympathize.

Also, thanks a lot for maintaining this project. I use leo-cli almost daily <3