### PR TITLE
Fix beautifulsoup4 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bs4
+beautifulsoup4
 requests>=2.0.0
 tabulate>=0.7.7
 lxml


### PR DESCRIPTION
PyPI has the bs4 package only to:

"prevent name squatting. The official name of PyPI’s Beautiful Soup Python package is beautifulsoup4. This package ensures that if you type pip install bs4 by mistake you will end up with Beautiful Soup." 

Fix this by using the official name.

Using "bs4" also prevented me to update the .spec file according Fedora's Python packaging guidelines (by not autogenerating the correct depedency in the RPM build process.)